### PR TITLE
Fix packet byte datatype

### DIFF
--- a/src/AsyncMqttClient.cpp
+++ b/src/AsyncMqttClient.cpp
@@ -393,7 +393,7 @@ void AsyncMqttClient::_onAck(AsyncClient* client, size_t len, uint32_t time) {
 void AsyncMqttClient::_onData(AsyncClient* client, char* data, size_t len) {
   (void)client;
   size_t currentBytePosition = 0;
-  char currentByte;
+  uint8_t currentByte;
   do {
     switch (_parsingInformation.bufferState) {
       case AsyncMqttClientInternals::BufferState::NONE:


### PR DESCRIPTION
On bk7231t, having currentByte as a char causes a problem when receiving packet types >= 8 (in the packet the type is in the high nibble, ie 0x80), when byte shifting >> 4 they get sign extended so we end up with packet type 0xf9 instead of 0x9 for suback.